### PR TITLE
Refactor CCM module: Expand-CCMCimProperty function, fix single resource configurations

### DIFF
--- a/Modules/CloudConfigurationManager/CloudConfigurationManager.psm1
+++ b/Modules/CloudConfigurationManager/CloudConfigurationManager.psm1
@@ -34,7 +34,7 @@
         if ($CimProperty.PropertyType.StartsWith('[MSFT_'))
         {
 
-            $cimResult = Expand-CCMCimProperty -CimInstaneValue $currentInstance.$propertyName
+            $cimResult = Expand-CCMCimProperty -CimInstanceValue $currentInstance.$propertyName
 
             if ($null -eq $cimResult)
             {
@@ -77,25 +77,25 @@ function Expand-CCMCimProperty
 
     $cimInstanceProperties = @{}
 
-    if ($CimInstanceValue -notin [System.Array])
-    {
-        $CimInstanceValue = @(CimInstanceValue)
-    }
+    # if ($CimInstanceValue -notin [System.Array])
+    # {
+    #     $CimInstanceValue = @($CimInstanceValue)
+    # }
 
     $cimPropertyNameBlacklist = @( 'CIMInstance', 'ResourceName')
 
     $cimResults = @()
 
-    #iterate over each object within the CimInstanceValueArray
+    #Iterate over each object within the CimInstanceValueArray
     foreach ($cimInstance in $CimInstanceValue)
     {
         $cimInstanceProperties = @{}
         # this is the current CIM Instance
-        foreach ($cimSubPropertyName in $cimEntry.Keys)
+        foreach ($cimSubPropertyName in $cimInstance.Keys)
         {
             if ($cimSubPropertyName -notin $cimPropertyNameBlacklist)
             {
-                $cimSubPropertyValue = $cimEntry.$cimSubPropertyName
+                $cimSubPropertyValue = $cimInstance.$cimSubPropertyName
                 if ($cimSubPropertyValue -is [System.Collections.Specialized.OrderedDictionary])
                 {
                     $cimSubPropertyValue = Expand-CCMCimProperty -CimInstanceValue $cimSubPropertyValue
@@ -104,6 +104,7 @@ function Expand-CCMCimProperty
                 $cimInstanceProperties.Add($cimSubPropertyName, $cimSubPropertyValue) | Out-Null
             }
         }
+
         $cimResult += New-CimInstance -ClassName $cimInstance.CIMInstance `
             -Property $cimInstanceProperties `
             -ClientOnly
@@ -193,7 +194,7 @@ function Test-CCMConfiguration
 
         # Evaluate the properties of the current resource.
         Write-Verbose -Message "[Test-CCMConfiguration]: Calling Test-TargetResource for {$ResourceInstanceName}"
-        $currentResult = Test-TargetResource @propertiesToSend
+        #$currentResult = Test-TargetResource @propertiesToSend
         Write-Verbose -Message "[Test-CCMConfiguration]: Test-TargetResource for {$ResourceInstanceName} returned {$currentResult}"
 
         # If a drift was detected, augment its related info with the name of the

--- a/Modules/CloudConfigurationManager/CloudConfigurationManager.psm1
+++ b/Modules/CloudConfigurationManager/CloudConfigurationManager.psm1
@@ -234,7 +234,7 @@ function Test-CCMConfiguration
 
         # Evaluate the properties of the current resource.
         Write-Verbose -Message "[Test-CCMConfiguration]: Calling Test-TargetResource for {$ResourceInstanceName}"
-        #$currentResult = Test-TargetResource @propertiesToSend
+        $currentResult = Test-TargetResource @propertiesToSend
         Write-Verbose -Message "[Test-CCMConfiguration]: Test-TargetResource for {$ResourceInstanceName} returned {$currentResult}"
 
         # If a drift was detected, augment its related info with the name of the


### PR DESCRIPTION
This will add improved handling of complex resources with nested instances of class objects or class objects that hold multiple objects of other class objects.

Previously, configurations like this would have issues during the creation of the CIMInstances.

```powershell
SCDLPComplianceRule e8434571-c5a8-47e9-b4af-fc961c15b96e {
            BlockAccess                         = $False;
            Comment                             = "This rule is matched if 1 to 9 credit card numbers are detected in a file when a user performs certain device-related activities. When detected within a 24-hour period, the activity is only audited (not blocked). Admins won't receive alerts.";
            ContentContainsSensitiveInformation = MSFT_SCDLPContainsSensitiveInformation {
                SensitiveInformation = @(
                    MSFT_SCDLPSensitiveInformation {
                        name           = 'Kreditkartennummer'
                        id             = '50842eb7-edc8-4019-85dd-5a5c1f2bb085'
                        maxconfidence  = '100'
                        minconfidence  = '85'
                        classifiertype = 'Content'
                        mincount       = '1'
                        maxcount       = '9'
                    }
                )
            }
            ;
            Credential                          = $Credscredential;
            Disabled                            = $False;
            DocumentIsPasswordProtected         = $False;
            DocumentIsUnsupported               = $False;
            Ensure                              = "Present";
            ExceptIfDocumentIsPasswordProtected = $False;
            ExceptIfDocumentIsUnsupported       = $False;
            ExceptIfHasSenderOverride           = $False;
            ExceptIfProcessingLimitExceeded     = $False;
            HasSenderOverride                   = $False;
            Name                                = "Default Endpoint DLP Policy Rule - Low Volume";
            Policy                              = "Default policy for devices";
            ProcessingLimitExceeded             = $False;
            RemoveRMSTemplate                   = $False;
            ReportSeverityLevel                 = "Low";
            StopPolicyProcessing                = $False;
        }
```

There are various resource that nest several CIM instances in each other.